### PR TITLE
feat: getColumnTitle with test added

### DIFF
--- a/easycsvpdf.js
+++ b/easycsvpdf.js
@@ -3,8 +3,12 @@
  *
  * @type {*}
  */
-const { jsPDF } = window.jspdf;
-
+let jsPDF;
+if (typeof window !== 'undefined' && window.jspdf) {
+    jsPDF = window.jspdf.jsPDF;
+} else {
+    jsPDF = require('jspdf').jsPDF;
+}
 /**
  * EasyCsvPdf
  * @class
@@ -188,12 +192,13 @@ class EasyCsvPdf {
     }
 
     /**
-     * Description placeholder
-     * TODO!!!
+     * Retrieves the column title at the specified index from the CSV data
      * @param {number} [index=0] 
      */
     getColumnTitle(index = 0) {
-
+        if (index >= 0 && index < this.titles.length) {
+            return this.titles[index];
+        }
     }
     /**
      * Description placeholder
@@ -458,5 +463,4 @@ class EasyCsvPdf {
 
 }
 
-
-
+module.exports = EasyCsvPdf;

--- a/easycsvpdf.js
+++ b/easycsvpdf.js
@@ -199,6 +199,13 @@ class EasyCsvPdf {
         if (index >= 0 && index < this.titles.length) {
             return this.titles[index];
         }
+        if (index < 0) {
+            return "[error]: index is lower than valid index";
+        }
+        if (index >= this.titles.length) {
+            return "[error]: index is greather than valid index";
+        }
+
     }
     /**
      * Description placeholder

--- a/jest-tests/easypdf.test.js
+++ b/jest-tests/easypdf.test.js
@@ -5,3 +5,15 @@ test('should retrieve column title when index is given', () => {
     const pdf = new EasyCsvPdf(csvData);
     expect(pdf.getColumnTitle(0)).toBe("Name");
 });
+
+test('should retrieve error when getColumnTitle index is lower than 0', () => {
+    const csvData = "Name,Age,Height\nJohn,32,180\nAlice,29,170";
+    const pdf = new EasyCsvPdf(csvData);
+    expect(pdf.getColumnTitle(-1)).toBe("[error]: index is lower than valid index");
+});
+
+test('should retrieve error when getColumnTitle index is equal to titles length', () => {
+    const csvData = "Name,Age,Height\nJohn,32,180\nAlice,29,170";
+    const pdf = new EasyCsvPdf(csvData);
+    expect(pdf.getColumnTitle(3)).toBe("[error]: index is greather than valid index");
+});

--- a/jest-tests/easypdf.test.js
+++ b/jest-tests/easypdf.test.js
@@ -1,0 +1,7 @@
+const EasyCsvPdf = require('../easycsvpdf.js');
+
+test('should retrieve column title when index is given', () => {
+    const csvData = "Name,Age,Height\nJohn,32,180\nAlice,29,170";
+    const pdf = new EasyCsvPdf(csvData);
+    expect(pdf.getColumnTitle(0)).toBe("Name");
+});

--- a/package.json
+++ b/package.json
@@ -15,13 +15,26 @@
   "type": "commonjs",
   "main": "easycsvpdf.js",
   "scripts": {
-    "test": "playwright test"
+    "test": "playwright test",
+    "test-jest": "jest"
+  },
+  "jest": {
+    "roots": [
+      "<rootDir>/jest-tests"
+    ],
+    "testMatch": [
+      "**/*.test.js"
+    ],
+    "testEnvironment": "jsdom"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.1",
+    "jest": "^30.0.3",
+    "jest-environment-jsdom": "^30.0.2",
     "playwright": "^1.53.1"
   },
   "dependencies": {
+    "jspdf": "2.5.1",
     "pdf-parse": "^1.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,7 @@
 // playwright.config.js
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
+    testIgnore: ['jest-tests/**'],
     use: {
         headless: false,  // <--- Aquí deshabilitas headless
         slowMo: 50,       // Opcional: para ralentizar un poco y ver lo que pasa


### PR DESCRIPTION
Added let variable to let code be testable against jest, becouse window wasn't working cause of node
Added description & logic of method getColumnTitle
Added module.exports to test it with jest
Added command: test-jest in package.json to test the EasyCsvPdf class methods.
Added configuration for jest to run only tests under jest-tests/ folder.
Added jspdf dependency with version 2.5.1 the same as used in index.html
Added configuration for playwright to ignore tests under jest-test/ folder.
Added test to verify the first column title has been retrieved to the user.